### PR TITLE
[Programmers] 124 나라의 숫자 - 김태현

### DIFF
--- a/Programmers/taehyoun/124 나라의 숫자.java
+++ b/Programmers/taehyoun/124 나라의 숫자.java
@@ -1,0 +1,40 @@
+import java.util.*;
+class Solution {
+    public String solution(int n) {
+        StringBuilder sb  = new StringBuilder();
+        while(n > 0){
+            int r = n % 3;
+            if(r == 0){
+                n = n/3 - 1; 
+                sb.append(4);
+            }else{
+                n/=3;
+                sb.append(r);
+            }
+        }
+        
+        return sb.reverse().toString();
+    }
+}
+
+
+//개선 코드
+class Solution {
+    public String solution(int n) {
+        StringBuilder result = new StringBuilder();
+        int[] digits = {4, 1, 2};
+        
+        while (n > 0) {
+            int remainder = n % 3;
+            n /= 3;
+
+            if (remainder == 0) {
+                n--; 
+            }
+
+            result.insert(0, digits[remainder]);
+        }
+
+        return result.toString();
+    }
+}


### PR DESCRIPTION
## ✅ PR 제출 전 체크리스트 (반드시 아래 항목들을 체크 후 올려주세요! 문제가 있다면 수정 후 올려주세요.)
- [x] PR 제목이 '[플랫폼명] 문제 제목 - 작성자' 형식을 따르고 있나요?
- [x] 커밋 메시지가 '[난이도] 문제 제목' 형식을 따르고 있나요?

숫자 3개만을 사용하므로 3진법을 떠올릴 수 있었지만 기존의 3진법과는 달리 0인 경우 4를 사용한다는 차이를 처리하는데 시간이 오래 걸렸습니다. 

아래와 같이 기존의 3진법과 124 나라의 3진법을 직접 매핑해보며 규칙을 찾을 수 있었습니다.

3진법 - 124 나라
0       -   표현 못함(해당 이유로 자연수만 존재한다는 조건 명시)    
1        -   1
2       -   2
10     -   4
11     -   11   
12     -   12
20     -   14
21     -   21
22     -   22
100   -   24
101    -  41
102    - 42
110    - 44
111     - 111

위의 매핑을 통해 3진법에서 0을 표현할때 124 나라에서는 4로 표현하는데서 차이가 있음을 알 수 있었고, 0을 124 나라에서 표현 못한다는 점으로 인해 124 나라의 숫자 체계는 3진법보다 표현하는 숫자 하나가 뒤로 밀렸다고 이해했습니다.

이러한 이유로 기존의 3진법처럼 3으로 나눈뒤 만약 나머지가 0일 경우에는 몫에서 1을 빼어 숫자 하나가 밀린 것을 보정하는 작업이 필요했습니다.

추가적으로 해당 문제의 숫자 체계를 10진법으로 변환하고자 한다면
'1','2','4'를 1, 2, 3의 값으로 각각 매핑해주면 되는데, 보정 작업이 왜필요한지 개인적으로 더 이해가 잘되어 정리해보았습니다.
ex)'14' => 3x'1' + 1x'3' = 6
기존의 3진법 '20' => 3x'2' + 1x'0' = 6